### PR TITLE
chore: run linting npm-scripts before a git commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run eslint:fix
+npm run mdlint

--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,12 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "husky": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
+      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "dev": true
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,19 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-filename-rules": "^1.2.0",
     "eslint-plugin-folders": "^1.0.3",
-    "eslint-plugin-import": "^2.24.2"
+    "eslint-plugin-import": "^2.24.2",
+    "husky": "^7.0.2"
   },
   "scripts": {
     "mdlint": "mdlint . --config .markdownlint.json",
     "eslint": "eslint --ext .js exercises/",
     "pretest": "npm run mdlint && npm run eslint",
-    "eslint:fix": "npm run eslint -- --fix"
+    "eslint:fix": "npm run eslint -- --fix",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/raulingg/gym.git"
+    "url": "git+https://github.com/Laboratoria/gym.git"
   },
   "license": "private",
   "bugs": {


### PR DESCRIPTION
We need to make sure all contributors follow the code rules around eslint and mdlint. So, one way to do that is by helping contributors get timely feedback about linting rules as early in the CI pipeline as possible

Git pre-commit hook allows us to execute scripts before a commit happens, it's probably the best moment to help devs follow rules.

fixes #70