### PR TITLE
Translate mock interview docs

### DIFF
--- a/docs/interviews/README.pt.md
+++ b/docs/interviews/README.pt.md
@@ -1,0 +1,3 @@
+# Guias de como executar a sessão  
+
+- [Primeira entrevista técnica (Graduada)](./first-tech-mock-interview/README-Coach.pt.md)

--- a/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
@@ -1,51 +1,52 @@
-# Guía minuto a minuto de como ejecutar la primer entrevista
+# Guia minuto a minuto de como executar a primeira entrevista
 
 ## Prework
 
-- Haber hecho la convocatoria a las egresadas.
-- Haber agendado en calendar y compartir el link de zoom a donde conectarse.
-- Haber compartido con la egresada [la guia para la primer entrevista](./README-Interviewer.md).
-- Acordar con la egresada que ejercicio ejecutar.
-- Haber compartido con la estudiante el contexto de como se vivirá el espacio
-(Solo si es necesario compartir este video
-[Job application Tips y buenas prácticas para entrevistas técnicas](https://youtu.be/0NMil00HKEU))
+- Ter feito a convocatória de graduadas.
+- Ter agendado no calendar e compartilhar o link de zoom aonde conectar-se.
+- Compartilhar com a graduada [a guia para a primeira entrevista](./README-Interviewer.pt.md).
+- Acordar com a graduada que exercício executar.
+- Compartilhar com a estudante o contexto de como se vivirá o espaço
+(Se necessário, compartilhar este vídeo
+[Job application Tips e boas práticas para entrevistas técnicas](https://youtu.be/rY8E1QmiQ0s)
+O vídeo está em espanhol, mas tem legenda em português)
 
-## Bienvenida dinámica (5 min)
+## Boas-vindas (5 min)
 
-Unx coach da la bienvenida, presenta a las egresadas, les da la palabra para que
-se presente respectivamente, menciona que estudiantes serán las entrevistadas y
-cual es la sala correspondiente para cada egresada.
+Um coach dá boas-vindas, apresenta as graduadas, lhes dá a palavra para que
+se apresentem respectivamente, menciona quais estudantes serão entrevistadas e
+qual é a sala correspondente para cada graduada.
 
 ## Ir a breakout rooms (2 min)
 
-Una vez que entremos a las salas, una coach hace el recordatorio del tiempo que
-se tiene para la entrevista y le da paso a la egresada para empezar la entrevista.
-(Solo si es necesario hace el recordatorio que las demás participantes apaguen cámaras).
-Por ultimo empezar a grabar la sesión.
+Assim que entramos nas salas, um coach faz um lembrete do tempo que
+se tem para a entrevista e dá lugar para a graduada iniciar a entrevista.
+(Se necessário, lembrar para que os outros participantes desliguem as cameras, não interajam no chat e que também tentem fazer os exercício proposto).
+Por fim, comece a gravar a sessão.
 
 ## Entrevista (30-40 min)
 
-La egresada toma el rol de la entrevistadora e interactúa con la estudiante.
+A graduada assume o papel de entrevistadora e interage com a estudante.
 
 ## Retrospective (20 min)
 
-Lx coach agradece la participación de la egresada y empieza a dirigir la retrospectiva
-(la presencia de la egresada es opcional), lx coach detona la reflexión con las
-siguientes preguntas:
+Lx coach agradece a participação da graduada e passa a dirigir a retrospectiva
+(a presença da graduada é opcional), lx coach provoca reflexão com o
+próximas perguntas:
 
-### Preguntas a la __entrevistada__
+### Perguntas a __entrevistada__
 
 - Como te sentiste?
-- Que crees que hiciste bien?
-- Que pudiste haber hecho mejor?
+- O que você acha que fez bem?
+- O que você poderia ter feito melhor?
 
-### Preguntas a las __espectadoras__
+### Perguntas as __espectadoras__
 
-- Que consideran que hizo bien la entrevistada?
-- Que creen que puede haber hecho mejor?
+- O que você acha que o entrevistado fez bem?
+- O que você acha que poderia ter sido feito melhor?
 
-## Peers comparten soluciones + Q&A (30 mins)
+## Q&A + Peers compartilhar soluções (30 mins)
 
-Se regresan a la sala principal y las estudiantes espectadoras comparten sus soluciones
-a los problemas mostrados.
-Las coaches abren un espacio para a responder las preguntas con respecto a entrevistas.
+Os coaches abrem um espaço para tirar dúvidas sobre as entrevistas.
+Voltamos para a sala principal e as estudantes espectadoras compartilham suas soluções
+aos problemas apresentados.

--- a/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
@@ -21,7 +21,8 @@ qual é a sala correspondente para cada graduada.
 
 Assim que entramos nas salas, um coach faz um lembrete do tempo que
 se tem para a entrevista e dá lugar para a graduada iniciar a entrevista.
-(Se necessário, lembrar para que os outros participantes desliguem as cameras, não interajam no chat e que também tentem fazer os exercício proposto).
+(Se necessário, lembrar para que os outros participantes desliguem as cameras,
+não interajam no chat e que também tentem fazer os exercício proposto).
 Por fim, comece a gravar a sessão.
 
 ## Entrevista (30-40 min)

--- a/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Coach.pt.md
@@ -1,0 +1,51 @@
+# Guía minuto a minuto de como ejecutar la primer entrevista
+
+## Prework
+
+- Haber hecho la convocatoria a las egresadas.
+- Haber agendado en calendar y compartir el link de zoom a donde conectarse.
+- Haber compartido con la egresada [la guia para la primer entrevista](./README-Interviewer.md).
+- Acordar con la egresada que ejercicio ejecutar.
+- Haber compartido con la estudiante el contexto de como se vivirá el espacio
+(Solo si es necesario compartir este video
+[Job application Tips y buenas prácticas para entrevistas técnicas](https://youtu.be/0NMil00HKEU))
+
+## Bienvenida dinámica (5 min)
+
+Unx coach da la bienvenida, presenta a las egresadas, les da la palabra para que
+se presente respectivamente, menciona que estudiantes serán las entrevistadas y
+cual es la sala correspondiente para cada egresada.
+
+## Ir a breakout rooms (2 min)
+
+Una vez que entremos a las salas, una coach hace el recordatorio del tiempo que
+se tiene para la entrevista y le da paso a la egresada para empezar la entrevista.
+(Solo si es necesario hace el recordatorio que las demás participantes apaguen cámaras).
+Por ultimo empezar a grabar la sesión.
+
+## Entrevista (30-40 min)
+
+La egresada toma el rol de la entrevistadora e interactúa con la estudiante.
+
+## Retrospective (20 min)
+
+Lx coach agradece la participación de la egresada y empieza a dirigir la retrospectiva
+(la presencia de la egresada es opcional), lx coach detona la reflexión con las
+siguientes preguntas:
+
+### Preguntas a la __entrevistada__
+
+- Como te sentiste?
+- Que crees que hiciste bien?
+- Que pudiste haber hecho mejor?
+
+### Preguntas a las __espectadoras__
+
+- Que consideran que hizo bien la entrevistada?
+- Que creen que puede haber hecho mejor?
+
+## Peers comparten soluciones + Q&A (30 mins)
+
+Se regresan a la sala principal y las estudiantes espectadoras comparten sus soluciones
+a los problemas mostrados.
+Las coaches abren un espacio para a responder las preguntas con respecto a entrevistas.

--- a/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
@@ -27,8 +27,8 @@ passou por cipher/card validation e data-lovers.
   Aqui começa a entrevista, e a primeira coisa é deixar claro para a candidata
   qual será a estrutura deste espaço, por exemplo:
   
-  > _"Vou te contar sobre o processo: no começo vou pedir que você se apresente, me diga
-   um pouco sobre você e finalmente resolveremos 1 ou 2 exercícios de código"_.
+  > _"Vou te contar sobre o processo: no começo vou pedir que você se apresente,
+me diga um pouco sobre você e finalmente resolveremos 1 ou 2 exercícios de código"_.
 
 - **Apresentação**
 
@@ -47,10 +47,10 @@ passou por cipher/card validation e data-lovers.
   O objetivo desta etapa é ver como a estudante enfrenta a
   resolução em tempo real de um exercício de código.
   
-  A recomendação é começar com algum exercício rápido e fácil para dar uma
-  idea do nivel da estudante, e a partir daí você pode avaliar se passa para um segundo exercício.
-  Quando o tempo acabar, se a estudante não tiver terminado o exercício,
-  você pode dar 5 minutos e perguntar "Com o que você continuaria e como chegaria à solução?"
+  A recomendação é começar com algum exercício rápido e fácil para dar uma idea do
+  nivel da estudante, e a partir daí pode avaliar se passa para um segundo exercício.
+  Quando o tempo acabar, se a estudante não tiver terminado o exercício, você pode
+  dar 5 minutos e perguntar "Com o que você continuaria e como chegaria à solução?"
   
 ## Encerramento
   

--- a/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
@@ -1,66 +1,64 @@
-# Guía para entrevista GYM
+# Guia para entrevista GYM
 
 ## Objetivo
 
-Que las estudiantes tenga una primer experiencia de entrevista técnica si tener
-que esperar a iniciar un proceso real
-con la complejidad que necesaria que abarcar el status actual.
+Que as estudantes tenham uma primeira experiência de entrevista técnica sem ter
+que esperar iniciar um processo real
+com a complexidade necessária para cobrir o status atual.
 
-## Status actual
+## Status atual
 
-La estudiante actualmente esta atravesando social network, ha
-pasado por cipher/card validation y data-lovers.
+A maioria das estudantes atualmente está fazendo o projeto social network, já
+passou por cipher/card validation e data-lovers.
 
-## Dinámica
+## Dinâmica
 
 ### Inicio (5-7 min)
 
 - **Contexto**
 
-  Antes de ponerte en modo entrevistadorx es importante recordar a la
-  estudiante que esta es una entrevista de práctica, es sobre todo para
-  identificar qué haría en una entrevista real, cómo se comportaría si se pone
-  nerviosa, o que recursos puede usar para controlar o manejar esas situaciones.
+  Antes de se colocar em modo de entrevistadora, é importante lembrar a
+  estudante de que esta é uma entrevista de práctica, é principalmente para
+  identificar o que você faria em uma entrevista real, como se comportaria se estivesse
+  nervosa, ou quais recursos você pode usar para controlar ou administrar essas situações.
 
 - **Intro**
 
-  Aquí ya comienza la entrevista y lo primero es dejarle claro a la candidata
-  cuál será la estructura de este espacio, por ejemplo:
+  Aqui começa a entrevista, e a primeira coisa é deixar claro para a candidata
+  qual será a estrutura deste espaço, por exemplo:
   
-  > _"Te comento el proceso: al comienzo te pediré que te presentes, me cuentes
-  un poco sobre tí y por último resolveremos 1 o 2 ejercicios de código"_.
+  > _"Vou te contar sobre o processo: no começo vou pedir que você se apresente, me diga
+   um pouco sobre você e finalmente resolveremos 1 ou 2 exercícios de código"_.
 
-- **Presentación**
+- **Apresentação**
 
-  En este punto, ya en modo entrevistadorx, te presentas y la invitas a ella a
-  que se presente. El foco aquí es que su presentación sea breve, clara
-  por lo que siéntete en libertad de hacerle las preguntas que consideres relevantes.
+  Nesse momento, já em modo de entrevistadora, você se apresenta e a convida para
+  que se apresente. O foco aqui é que sua apresentação seja breve e clara,
+  portanto, sinta-se à vontade para fazer qualquer pergunta que considere relevante
   
-  > Ejemplo de preguntas:
+  > Exemplo de perguntas:
   >
-  > - ¿Por que te intereso entrar al mundo de la programación ?
-  > - ¿Que es lo que mas disfrutas de programar?
-  > - ¿Que rol te gustaría tener o que te gustaría estar haciendo?
+  > - Por que você se interessou em entrar no mundo da programação?
+  > - O que você mais gosta da área da programação?
+  > - Que função/papel você gostaria de ter ou o que gostaria de estar fazendo?
   
-## Ejercicio técnico (25 min)
+## Exercício técnico (25 min)
 
-  El objetivo de esta etapa es ver cómo se enfrenta la estudiante a la
-  resolución en tiempo real de un ejercicio de código.
+  O objetivo desta etapa é ver como a estudante enfrenta a
+  resolução em tempo real de um exercício de código.
   
-  La recomendación es comenzar con algún ejercicio rápido y fácil para darte una
-  idea del nivel de la estudiante, y de ahí puedes valor si pasar a un segundo ejercicio,
-  cuando acabe el tiempo si la estudiante no ha terminado el ejercicio,
-  puedes darle 5 min y preguntarle ¿Con que seguiría y  como llegaría a la solución?
+  A recomendação é começar com algum exercício rápido e fácil para dar uma
+  idea do nivel da estudante, e a partir daí você pode avaliar se passa para um segundo exercício.
+  Quando o tempo acabar, se a estudante não tiver terminado o exercício,
+  você pode dar 5 minutos e perguntar "Com o que você continuaria e como chegaria à solução?"
   
-## Cierre
+## Encerramento
   
-  Aquí llega la entrevista a su fin y finaliza tu rol de entrevistadorx, puedes
-  compartir algo de feedback.
+Aqui a entrevista é finalizada e seu papel como entrevistadora termina.
+Você pode compartilhar alguns feedbacks.
 
-## Ejemplos de entrevistas
+## Exemplos de entrevistas
 
-[![Mock mock interview 21/04/2022 by Margarita](https://img.youtube.com/vi/JPwObIeVSgw/0.jpg)](https://youtu.be/JPwObIeVSgw)
+[![Mock mock interview 26/10/2022 by Marina](https://img.youtube.com/vi/AybAbA4_Xg0/0.jpg)](https://youtu.be/AybAbA4_Xg0)
 
-[![Mock mock interview 5/05/2022 by Isabela](https://img.youtube.com/vi/35Yr3XtRDIg/0.jpg)](https://youtu.be/35Yr3XtRDIg)
-
-[![Mock Interview sesión 10 - 7/10/2021 by Melisa & Fernando](https://img.youtube.com/vi/TEbiUVmZIS4/0.jpg)](https://www.youtube.com/watch?v=TEbiUVmZIS4)
+[![Mock mock interview 11/05/2022 by Thais](https://img.youtube.com/vi/hTau4gdt7Fs/0.jpg)](https://youtu.be/hTau4gdt7Fs)

--- a/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
+++ b/docs/interviews/first-tech-mock-interview/README-Interviewer.pt.md
@@ -1,0 +1,66 @@
+# Guía para entrevista GYM
+
+## Objetivo
+
+Que las estudiantes tenga una primer experiencia de entrevista técnica si tener
+que esperar a iniciar un proceso real
+con la complejidad que necesaria que abarcar el status actual.
+
+## Status actual
+
+La estudiante actualmente esta atravesando social network, ha
+pasado por cipher/card validation y data-lovers.
+
+## Dinámica
+
+### Inicio (5-7 min)
+
+- **Contexto**
+
+  Antes de ponerte en modo entrevistadorx es importante recordar a la
+  estudiante que esta es una entrevista de práctica, es sobre todo para
+  identificar qué haría en una entrevista real, cómo se comportaría si se pone
+  nerviosa, o que recursos puede usar para controlar o manejar esas situaciones.
+
+- **Intro**
+
+  Aquí ya comienza la entrevista y lo primero es dejarle claro a la candidata
+  cuál será la estructura de este espacio, por ejemplo:
+  
+  > _"Te comento el proceso: al comienzo te pediré que te presentes, me cuentes
+  un poco sobre tí y por último resolveremos 1 o 2 ejercicios de código"_.
+
+- **Presentación**
+
+  En este punto, ya en modo entrevistadorx, te presentas y la invitas a ella a
+  que se presente. El foco aquí es que su presentación sea breve, clara
+  por lo que siéntete en libertad de hacerle las preguntas que consideres relevantes.
+  
+  > Ejemplo de preguntas:
+  >
+  > - ¿Por que te intereso entrar al mundo de la programación ?
+  > - ¿Que es lo que mas disfrutas de programar?
+  > - ¿Que rol te gustaría tener o que te gustaría estar haciendo?
+  
+## Ejercicio técnico (25 min)
+
+  El objetivo de esta etapa es ver cómo se enfrenta la estudiante a la
+  resolución en tiempo real de un ejercicio de código.
+  
+  La recomendación es comenzar con algún ejercicio rápido y fácil para darte una
+  idea del nivel de la estudiante, y de ahí puedes valor si pasar a un segundo ejercicio,
+  cuando acabe el tiempo si la estudiante no ha terminado el ejercicio,
+  puedes darle 5 min y preguntarle ¿Con que seguiría y  como llegaría a la solución?
+  
+## Cierre
+  
+  Aquí llega la entrevista a su fin y finaliza tu rol de entrevistadorx, puedes
+  compartir algo de feedback.
+
+## Ejemplos de entrevistas
+
+[![Mock mock interview 21/04/2022 by Margarita](https://img.youtube.com/vi/JPwObIeVSgw/0.jpg)](https://youtu.be/JPwObIeVSgw)
+
+[![Mock mock interview 5/05/2022 by Isabela](https://img.youtube.com/vi/35Yr3XtRDIg/0.jpg)](https://youtu.be/35Yr3XtRDIg)
+
+[![Mock Interview sesión 10 - 7/10/2021 by Melisa & Fernando](https://img.youtube.com/vi/TEbiUVmZIS4/0.jpg)](https://www.youtube.com/watch?v=TEbiUVmZIS4)


### PR DESCRIPTION
No teníamos la tradución de los archivos docs para hacer las primeras mock-mock tech interview.. 
no teníamos para los coaches y tampoco para compartir com egresadas.

Fuera hecho:
- la tradución literal
- cambiado los links (anchor to los readmes en pt)
- cambiando los videos de ejemplos para otros q tenemos en portugues
- cambiado el video de tips (para lo que tenemos subtitles en pt - la traduccion automatica de yt era muy mala y por eso bajamos e subimos en nuestro channel con subtitles hechos manualmente)
- cambiamos la orden de `Peers comparten soluciones + Q&A (30 mins)` en `Coach.pt.md`
- añadimos otros recordatórios `coach.pt.md` en linea 24 e 25